### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: base-flow
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mingchiuli/megalith-frontend/security/code-scanning/1](https://github.com/mingchiuli/megalith-frontend/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the GITHUB_TOKEN. Since the workflow only needs to read repository contents (for checkout and build), set `contents: read` at the workflow level (top-level, just below `name:` and before `on:`). This will apply to all jobs in the workflow unless overridden. No other permissions appear necessary for the current steps.

Edit the file `.github/workflows/main.yml` by inserting the following block:

```yaml
permissions:
  contents: read
```

immediately after the `name: base-flow` line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
