### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete URL scheme check

### DIFF
--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -18,10 +18,8 @@ export const sanitizeHighlight = (html: string): string => {
     // Remove event handlers like onclick, onerror, etc.
     .replace(/on\w+="[^"]*"/gi, '')
     .replace(/on\w+='[^']*'/gi, '')
-    // Remove javascript: URLs
-    .replace(/javascript:/gi, '')
-    // Remove data: URLs that could contain malicious content
-    .replace(/data:\s*text\/html/gi, '')
+    // Remove dangerous executable URL schemes
+    .replace(/\b(?:javascript|data|vbscript)\s*:/gi, '')
 
   return sanitized
 }


### PR DESCRIPTION
Potential fix for [https://github.com/mingchiuli/megalith-frontend/security/code-scanning/10](https://github.com/mingchiuli/megalith-frontend/security/code-scanning/10)

General fix: when sanitizing untrusted HTML/text, scheme filtering must consistently block all dangerous executable schemes, not just `javascript:`. At minimum include `data:` and `vbscript:` checks/removals.

Best targeted fix in `src/utils/sanitize.ts`: replace the current two scheme-related replacements in `sanitizeHighlight` with a single regex that removes any occurrence of `javascript:`, `data:`, or `vbscript:` (case-insensitive, with optional whitespace before colon). This preserves existing behavior (string-based sanitization) while closing the incomplete-check gap flagged by CodeQL.

Change region: inside `sanitizeHighlight`, lines around current comments/replacements 21–24.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
