### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete multi-character sanitization

### DIFF
--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -31,17 +31,25 @@ export const sanitizeHighlight = (html: string): string => {
 export const sanitizeMarkdown = (html: string): string => {
   if (!html) return ''
 
-  // Remove script tags
-  const sanitized = html
-    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-    // Remove iframe tags
-    .replace(/<iframe\b[^>]*>.*?<\/iframe>/gi, '')
-    // Remove object/embed tags
-    .replace(/<object\b[^>]*>.*?<\/object>/gi, '')
-    .replace(/<embed\b[^>]*>/gi, '')
-    // Remove event handlers
-    .replace(/on\w+="[^"]*"/gi, '')
-    .replace(/on\w+='[^']*'/gi, '')
+  let sanitized = html
+  let previous: string
+
+  // Repeatedly apply removals to avoid incomplete multi-character sanitization
+  // where one replacement can expose another dangerous pattern.
+  do {
+    previous = sanitized
+    sanitized = sanitized
+      // Remove script tags
+      .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+      // Remove iframe tags
+      .replace(/<iframe\b[^>]*>.*?<\/iframe>/gi, '')
+      // Remove object/embed tags
+      .replace(/<object\b[^>]*>.*?<\/object>/gi, '')
+      .replace(/<embed\b[^>]*>/gi, '')
+      // Remove event handlers
+      .replace(/on\w+="[^"]*"/gi, '')
+      .replace(/on\w+='[^']*'/gi, '')
+  } while (sanitized !== previous)
 
   return sanitized
 }


### PR DESCRIPTION
Potential fix for [https://github.com/mingchiuli/megalith-frontend/security/code-scanning/8](https://github.com/mingchiuli/megalith-frontend/security/code-scanning/8)

To fix this safely without changing intended behavior, apply the dangerous-tag removals repeatedly until the string stabilizes (no further changes). This addresses incomplete multi-character sanitization by ensuring newly exposed `<script...>`/`<iframe...>`/`<object...>` patterns are also removed in subsequent passes.

Best single fix in `src/utils/sanitize.ts`:
- In `sanitizeMarkdown`, replace the current one-pass chained replacement with a loop:
  - initialize `sanitized = html`
  - in a `do...while`, keep previous value and re-run the same replacement chain
  - stop when `sanitized === previous`
- Keep the existing regexes and behavior otherwise unchanged.
- No new imports or dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
